### PR TITLE
Add Campaign.get_all() method.

### DIFF
--- a/dotmailer/campaigns.py
+++ b/dotmailer/campaigns.py
@@ -251,3 +251,25 @@ class Campaign(Base):
         self.sends[send.id] = send
         return self
 
+    @classmethod
+    def get_all(cls):
+        """Gets all campaigns
+
+        :return: List of Campaigns
+        """
+        all_campaigns = []
+        select = 1000
+        skip = 0
+
+        while True:
+            response = connection.get(cls.end_point, query_params={'Select': select, 'Skip': skip})
+            campaigns = [cls(**campaign) for campaign in response]
+            all_campaigns.extend(campaigns)
+
+            if len(campaigns) < select:
+                # This means there are no more campaigns to fetch.
+                break
+
+            skip += select
+
+        return all_campaigns

--- a/dotmailer/transactional_emails.py
+++ b/dotmailer/transactional_emails.py
@@ -86,10 +86,10 @@ class TransactionEmail(Base):
         )
 
     @classmethod
-    def send_transactional_triggered_campaign(cls, to_address, campaign_id, personalisation_values=None):
+    def send_transactional_triggered_campaign(cls, to_addresses, campaign_id, personalisation_values=None):
         """
         
-        :param to_address: A single email address which the campaign should be sent to.
+        :param to_addresses: A list of email addresses which the campaign should be sent to.
         :param campaign_id: The DotMailer ID value of the campaign you wish to trigger.
         :param personalisation_values: A dictionary of any personalisation values that should be used to fill in the
          email.
@@ -99,7 +99,7 @@ class TransactionEmail(Base):
 
         # TODO: Waiting to hear back from DotMailer to find out if you send multiple recipients how personalisation values are handled
         param_data = {
-            'toAddress': [to_address],
+            'toAddresses': to_addresses,
             'campaignId': campaign_id
         }
         if personalisation_values is not None:

--- a/dotmailer/transactional_emails.py
+++ b/dotmailer/transactional_emails.py
@@ -103,7 +103,7 @@ class TransactionEmail(Base):
             'campaignId': campaign_id
         }
         if personalisation_values is not None:
-            param_data['personalisationValues'] = [
+            param_data['personalizationValues'] = [
                 {'Name': key, 'Value': value} for key, value in personalisation_values.items()
             ]
 


### PR DESCRIPTION
Add Campaign.get_all() method.

Also update POST param when sending triggered campaigns. Dotmailer expects `toAddress` to be plural. ie. `toAddresses`

https://developer.dotmailer.com/docs/send-transactional-email-using-a-triggered-campaign

Also personalisation needs to be spelt in American English.